### PR TITLE
Use lastNotifiedMessage in Raíces client

### DIFF
--- a/cmd/almendruco/main.go
+++ b/cmd/almendruco/main.go
@@ -71,7 +71,7 @@ func notifyMessages(r repo.Repo, rc raices.Client, n notifier.Notifier) error {
 			return errors.New("Raíces client returned no messages")
 		}
 
-		if err := n.Notify(notifier.ChatID(chatID), msgs[0:5]); err != nil {
+		if err := n.Notify(notifier.ChatID(chatID), msgs); err != nil {
 			return fmt.Errorf("error notifying messages: %s", err)
 		}
 	}

--- a/internal/raices/models.go
+++ b/internal/raices/models.go
@@ -2,13 +2,20 @@ package raices
 
 import "time"
 
-type messagesResponse struct {
-	Status   status       `json:"ESTADO"`
-	Messages []rawMessage `json:"RESULTADO"`
+type loginResponse struct {
+	Status status `json:"ESTADO"`
 }
 
 type status struct {
-	Code string `json:"CODIGO"`
+	Code        string `json:"CODIGO"`
+	Description string `json:"DESCRIPCION,omitempty"`
+}
+
+const statusCodeOK string = "C"
+
+type messagesResponse struct {
+	Status   status       `json:"ESTADO"`
+	Messages []rawMessage `json:"RESULTADO"`
 }
 
 type rawMessage struct {


### PR DESCRIPTION
## Context
Only new messages need to be notified to the user. Each time messages are notified, the ID of the last message that was notified is stored so that we can know if messages fetched from the server are new or not.

## Changes
This PR implements the changes needed in Raíces client so that only messages that are new are fetched and returned. To do so, message IDs are checked against the last notified message ID, as IDs returned by the server are monotonically increasing. Thanks to this property, knowing if a message is new or not is as easy as checking whether its ID is greater than the ID of the last message that was notified.

Additionally, this check for new messages allows the client to know when to stop requesting message pages from the server.