### PR TITLE
Improve telegram notification message formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.16
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20211005215030-d2e5035098b3
 	golang.org/x/text v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/aws/aws-lambda-go v1.27.0 h1:aLzrJwdyHoF1A18YeVdJjX8Ixkd+bpogdxVInvHc
 github.com/aws/aws-lambda-go v1.27.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-sdk-go v1.41.2 h1:jiWC3Wq5tmSUY6XWZxkqMXE7WDQ22m7eECQi0xufQ30=
 github.com/aws/aws-sdk-go v1.41.2/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,6 +12,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -21,6 +25,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
+github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -69,16 +69,17 @@ func (tn *telegramNotifier) Notify(chatID ChatID, msgs []raices.Message) error {
 }
 
 func formatText(m raices.Message) string {
-	attachments := "no"
-	if m.ContainsAttachments {
-		attachments = "sí"
-	}
-
 	sentDate := m.SentDate.Format(dateFormat)
 	body := preprocess(m.Body)
 
-	return fmt.Sprintf("Nuevo mensaje en Raíces!\n\n<b>Fecha:</b> %s\n<b>De:</b> %s\n<b>Asunto:</b> %s\n\n%s\n\n<b>Adjuntos:</b> %s",
-		sentDate, m.Sender, m.Subject, body, attachments)
+	text := fmt.Sprintf("Nuevo mensaje en Raíces!\n\n<b>Fecha:</b> %s\n<b>De:</b> %s\n<b>Asunto:</b> %s\n\n%s",
+		sentDate, m.Sender, m.Subject, body)
+
+	if m.ContainsAttachments {
+		text = fmt.Sprintf("%s\n\n<b>Adjuntos:</b>\n%s", text, formatAttachments(m.Attachments))
+	}
+
+	return text
 }
 
 func preprocess(html string) string {
@@ -86,4 +87,13 @@ func preprocess(html string) string {
 
 	p := bluemonday.StrictPolicy()
 	return p.Sanitize(processed)
+}
+
+func formatAttachments(attachments []raices.Attachment) string {
+	var sb strings.Builder
+	for _, a := range attachments {
+		sb.WriteString(fmt.Sprintf("\t\t\t%s\n", a.FileName))
+	}
+
+	return sb.String()
 }

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -69,21 +69,22 @@ func (tn *telegramNotifier) Notify(chatID ChatID, msgs []raices.Message) error {
 }
 
 func formatText(m raices.Message) string {
-	sentDate := m.SentDate.Format(dateFormat)
-	body := preprocess(m.Body)
-
-	text := fmt.Sprintf("Nuevo mensaje en Raíces!\n\n<b>Fecha:</b> %s\n<b>De:</b> %s\n<b>Asunto:</b> %s\n\n%s",
-		sentDate, m.Sender, m.Subject, body)
+	var sb strings.Builder
+	sb.WriteString("Nuevo mensaje en Raíces!")
+	sb.WriteString(fmt.Sprintf("\n\n<b>Fecha:</b> %s", m.SentDate.Format(dateFormat)))
+	sb.WriteString(fmt.Sprintf("\n<b>De:</b> %s", m.Sender))
+	sb.WriteString(fmt.Sprintf("\n<b>Asunto:</b> %s", m.Subject))
+	sb.WriteString(fmt.Sprintf("\n\n%s", formatBody(m.Body)))
 
 	if m.ContainsAttachments {
-		text = fmt.Sprintf("%s\n\n<b>Adjuntos:</b>\n%s", text, formatAttachments(m.Attachments))
+		sb.WriteString(fmt.Sprintf("\n\n<b>Adjuntos:</b>\n%s", formatAttachments(m.Attachments)))
 	}
 
-	return text
+	return sb.String()
 }
 
-func preprocess(html string) string {
-	processed := strings.Replace(html, "<div>", "\n", -1)
+func formatBody(body string) string {
+	processed := strings.Replace(body, "<div>", "\n", -1)
 
 	p := bluemonday.StrictPolicy()
 	return p.Sanitize(processed)


### PR DESCRIPTION
Use markup to improve the formatting of messages sent to users. HTML `parse_mode` was used as `MarkdownV2` implies escaping any character that could potentially be confused with markdown.

HTML tags are also stripped from message bodies using [bluemonday HTLM sanitizer](https://github.com/microcosm-cc/bluemonday) for strict sanitization of HTML input. Before that, `<div>` tags are naively replaced by `\n` to try to mimic the original intention of the sender.

Finally, attachment file names are also included in the notification messages. Even though they cannot be downloaded yet directly, letting the user know their names helps them decide whether checking the message in Raíces is worth it.