### PR TITLE
Track last notified message

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -5,5 +5,5 @@ import "github.com/volmedo/almendruco.git/internal/raices"
 type ChatID uint64
 
 type Notifier interface {
-	Notify(chatID ChatID, msgs []raices.Message) error
+	Notify(chatID ChatID, msgs []raices.Message) (uint64, error)
 }

--- a/internal/notifier/telegram_test.go
+++ b/internal/notifier/telegram_test.go
@@ -39,7 +39,7 @@ func TestNotify(t *testing.T) {
 		assert.Equal(t, "123456789", reqChatID)
 
 		reqText := r.Form.Get(textParam)
-		expectedText := "New message arrived to Raíces!\nFrom: Test Sender\nSubject: Test Subject\nHi you, this is a test message\nAttachments: true"
+		expectedText := "Nuevo mensaje en Raíces!\n\n<b>Fecha:</b> 11/11/2021 00:00\n<b>De:</b> Test Sender\n<b>Asunto:</b> Test Subject\n\nHi you, this is a test message\n\n<b>Adjuntos:</b>\n\t\t\tattachment.file\n"
 		assert.Equal(t, expectedText, reqText)
 
 		w.WriteHeader(http.StatusOK)
@@ -49,6 +49,7 @@ func TestNotify(t *testing.T) {
 	tn, err := NewTelegramNotifier(svr.URL, "test_token")
 	require.NoError(t, err)
 
-	err = tn.Notify(chatID, []raices.Message{msg})
+	lastNotifiedMessage, err := tn.Notify(chatID, []raices.Message{msg})
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(123456), lastNotifiedMessage)
 }

--- a/internal/raices/client.go
+++ b/internal/raices/client.go
@@ -83,12 +83,12 @@ func (c *client) FetchMessages(creds repo.Credentials, lastNotifiedMessage uint6
 			return []Message{}, err
 		}
 
-		msgs = append(msgs, parsed...)
-
 		numMsgs = len(parsed)
+
+		msgs = append(msgs, parsed...)
 	}
 
-	return msgs, nil
+	return reverse(msgs), nil
 }
 
 func (c *client) login(creds repo.Credentials) error {
@@ -177,4 +177,13 @@ func parse(raw []rawMessage) ([]Message, error) {
 	}
 
 	return parsed, nil
+}
+
+func reverse(msgs []Message) []Message {
+	reversed := make([]Message, 0, len(msgs))
+	for i := len(msgs) - 1; i >= 0; i-- {
+		reversed = append(reversed, msgs[i])
+	}
+
+	return reversed
 }

--- a/internal/raices/models.go
+++ b/internal/raices/models.go
@@ -29,6 +29,17 @@ type rawMessage struct {
 	ReadDate            string       `json:"F_LECTURA"`
 }
 
+type Message struct {
+	ID                  uint64
+	SentDate            time.Time
+	Sender              string
+	Subject             string
+	Body                string
+	ContainsAttachments bool
+	Attachments         []Attachment
+	ReadDate            time.Time
+}
+
 type Attachment struct {
 	ID       uint64 `json:"X_ADJMENSAL"`
 	FileName string `json:"T_NOMFIC"`
@@ -69,15 +80,4 @@ func parseMessage(rm rawMessage) (Message, error) {
 		Attachments:         rm.Attachments,
 		ReadDate:            readDate,
 	}, nil
-}
-
-type Message struct {
-	ID                  uint64
-	SentDate            time.Time
-	Sender              string
-	Subject             string
-	Body                string
-	ContainsAttachments bool
-	Attachments         []Attachment
-	ReadDate            time.Time
 }

--- a/internal/repo/dynamodbrepo/dynamodb.go
+++ b/internal/repo/dynamodbrepo/dynamodb.go
@@ -1,8 +1,8 @@
 package dynamodbrepo
 
 import (
-	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -54,5 +54,25 @@ func (dr *dynamoDBRepo) GetChats() ([]repo.Chat, error) {
 }
 
 func (dr *dynamoDBRepo) UpdateLastNotifiedMessage(chatID string, lastNotifiedMessage uint64) error {
-	return errors.New("not implemented yet")
+	input := &dynamodb.UpdateItemInput{
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":last": {
+				N: aws.String(strconv.FormatUint(lastNotifiedMessage, 10)),
+			},
+		},
+		Key: map[string]*dynamodb.AttributeValue{
+			"id": {
+				S: aws.String(chatID),
+			},
+		},
+		TableName:        aws.String(tableName),
+		UpdateExpression: aws.String("SET lastNotifiedMessage = :last"),
+	}
+
+	_, err := dr.db.UpdateItem(input)
+	if err != nil {
+		return fmt.Errorf("update last notified message failed: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Context

This service is designed to be run as a serverless function. On each scheduled invocation, it will retrieve messages and send notifications to the corresponding chat. Of course, we only want to send notifications for messages that have not been notified. In order to do so, keeping track of the message that was last notified is required.

## Implementation

We will store the corresponding last notified message ID in each DB record. The message client will receive the number as a parameter so that it knows when to stop requesting messages from the server. Then, the notifier will return the last notified message ID, which will be updated in the DB.