### PR TITLE
Configure CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Test and build
+name: Check, test and build
 
 on: [push, pull_request]
 
 jobs:
-  test-and-build:
+  check-code:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -14,8 +14,24 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        skip-go-installation: true
+    
     - name: Test
       run: go test -v ./...
-    
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
     - name: Build
       run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-  build-and-package:
+  build-and-update-dry-run:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -38,3 +40,54 @@ jobs:
 
     - name: Package
       run: zip almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip almendruco
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 900
+
+    - name: Update lambda
+      run: |
+        aws lambda update-function-code \
+          --function-name almendruco \
+          --zip-file fileb://almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip \
+          --dry-run \
+          >/dev/null
+
+  build-and-update:
+    runs-on: ubuntu-latest
+    needs: 
+      - check-code
+      - build-and-update-dry-run
+    permissions:
+      id-token: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Build
+      run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
+
+    - name: Package
+      run: zip almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip almendruco
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 900
+
+    - name: Update lambda
+      run: |
+        aws lambda update-function-code \
+          --function-name almendruco \
+          --zip-file fileb://almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip \
+          >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
-name: Check, test and build
+name: Check, build and deploy
 
 on: [push, pull_request]
 
 jobs:
   check-code:
+    name: Check code
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -22,7 +23,8 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-  build-and-update-dry-run:
+  build-and-deploy-dry-run:
+    name: Build and deploy (dry run)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -38,8 +40,12 @@ jobs:
     - name: Build
       run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
 
-    - name: Package
-      run: zip almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip almendruco
+    - name: Pack
+      id: pack
+      run: |
+        PACKAGE_NAME=almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
+        zip $PACKAGE_NAME almendruco
+        echo "::set-output name=package-name::$PACKAGE_NAME"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -48,20 +54,21 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 900
 
-    - name: Update lambda
+    - name: Update lambda (dry run)
       run: |
         aws lambda update-function-code \
           --function-name almendruco \
-          --zip-file fileb://almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip \
+          --zip-file fileb://${{ steps.pack.outputs.package-name }} \
           --dry-run \
           >/dev/null
 
-  build-and-update:
+  build-and-deploy:
+    name: Build and deploy (production, main only)
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: 
       - check-code
-      - build-and-update-dry-run
+      - build-and-deploy-dry-run
     permissions:
       id-token: write
     steps:
@@ -76,8 +83,12 @@ jobs:
     - name: Build
       run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
 
-    - name: Package
-      run: zip almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip almendruco
+    - name: Pack
+      id: pack
+      run: |
+        PACKAGE_NAME=almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
+        zip $PACKAGE_NAME almendruco
+        echo "::set-output name=package-name::$PACKAGE_NAME"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -90,5 +101,5 @@ jobs:
       run: |
         aws lambda update-function-code \
           --function-name almendruco \
-          --zip-file fileb://almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip \
+          --zip-file fileb://${{ steps.pack.outputs.package-name }} \
           >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,13 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-  build-and-deploy-dry-run:
-    name: Build and deploy (dry run)
+  build-and-pack:
+    name: Build and pack
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    outputs:
+      package-name: ${{ steps.pack.outputs.package-name }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -46,6 +48,25 @@ jobs:
         PACKAGE_NAME=almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
         zip $PACKAGE_NAME almendruco
         echo "::set-output name=package-name::$PACKAGE_NAME"
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: package
+        path: ${{ steps.pack.outputs.package-name }}
+
+  deploy-dry-run:
+    name: Deploy (dry-run)
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-pack
+    permissions:
+      id-token: write
+    steps:
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: package
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -54,41 +75,29 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 900
 
-    - name: Update lambda (dry run)
+    - name: Update lambda (dry-run)
       run: |
         aws lambda update-function-code \
           --function-name almendruco \
-          --zip-file fileb://${{ steps.pack.outputs.package-name }} \
+          --zip-file fileb://${{ needs.build-and-pack.outputs.package-name }} \
           --dry-run \
           >/dev/null
 
-  build-and-deploy:
-    name: Build and deploy (production, main only)
+  deploy:
+    name: Deploy (production, main only)
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: 
       - check-code
-      - build-and-deploy-dry-run
+      - build-and-pack
+      - deploy-dry-run
     permissions:
       id-token: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
       with:
-        go-version: 1.16
-
-    - name: Build
-      run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
-
-    - name: Pack
-      id: pack
-      run: |
-        PACKAGE_NAME=almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
-        zip $PACKAGE_NAME almendruco
-        echo "::set-output name=package-name::$PACKAGE_NAME"
+        name: package
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -101,5 +110,5 @@ jobs:
       run: |
         aws lambda update-function-code \
           --function-name almendruco \
-          --zip-file fileb://${{ steps.pack.outputs.package-name }} \
+          --zip-file fileb://${{ needs.build-and-pack.outputs.package-name }} \
           >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
   build-and-update:
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: 
       - check-code
       - build-and-update-dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-  build:
+  build-and-package:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -35,3 +35,6 @@ jobs:
 
     - name: Build
       run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
+
+    - name: Package
+      run: zip almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip almendruco

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Test and build
+
+on: [push, pull_request]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Test
+      run: go test -v ./...
+    
+    - name: Build
+      run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go

--- a/internal/raices/client_test.go
+++ b/internal/raices/client_test.go
@@ -78,7 +78,7 @@ func happyLoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, loginCk)
 	w.WriteHeader(200)
-	w.Write([]byte(testResp))
+	_, _ = w.Write([]byte(testResp))
 }
 
 func happyMessagesHandler(w http.ResponseWriter, r *http.Request) {
@@ -198,5 +198,5 @@ func multiPageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(messagesResp)
+	_ = json.NewEncoder(w).Encode(messagesResp)
 }

--- a/internal/raices/client_test.go
+++ b/internal/raices/client_test.go
@@ -40,15 +40,19 @@ func TestFetchMessages(t *testing.T) {
 	require.NoError(t, err, "Unexpected error fetching messages")
 	require.Equal(t, 1, len(msgs), "Expected 1 message")
 
+	// Time strings reported by Raices are always CET/CEST
+	cet, err := time.LoadLocation("CET")
+	require.NoError(t, err, "Failed to load CET/CEST timezone data")
+
 	expected := Message{
 		ID:                  12345678,
-		SentDate:            time.Date(2021, time.October, 1, 18, 27, 0, 0, time.Local),
+		SentDate:            time.Date(2021, time.October, 1, 18, 27, 0, 0, cet),
 		Sender:              "Jon Doe (Director)",
 		Subject:             "SOME SUBJECT",
 		Body:                "A message with some HTML entities&nbsp; and <div>markup</div>",
 		ContainsAttachments: true,
 		Attachments:         []Attachment{{ID: 123456, FileName: "Some File.ext"}},
-		ReadDate:            time.Date(2021, time.October, 2, 19, 3, 00, 00, time.Local),
+		ReadDate:            time.Date(2021, time.October, 2, 19, 3, 00, 00, cet),
 	}
 
 	if diff := cmp.Diff(expected, msgs[0]); diff != "" {


### PR DESCRIPTION
Configure GitHub Actions workflow to check, build and deploy code.

The resulting binary is meant to run as a lambda in AWS. Thus, authentication is needed to deploy the freshly built code. I used [OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) instead of standard roles as it allows the creation of disposable tokens. Some configuration is required on AWS' side, such as adding [GitHub's OIDC provider as an identity provider](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) and [creating a role to be assumed from the Actions workflow and configure it with the right permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html).

Deployment is split from building and packaging the binary so that code is built once while allowing a dry run of the deployment job. This ensures everything is in place before applying changes in the execution environment for real.

Finally, while a deployment dry run is done from any development branch, only code from `main` is actually uploaded to AWS.