### PR TITLE
Put commands in scripts and add a Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,24 @@ jobs:
       with:
         go-version: 1.16
 
-    - name: lint
+    - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
         skip-go-installation: true
     
+    - name: Tidy
+      run: bash scripts/tidy.sh
+
     - name: Test
-      run: go test -v ./...
+      run: bash scripts/test.sh
 
   build-and-pack:
     name: Build and pack
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      BINARY_NAME: almendruco
     outputs:
       package-name: ${{ steps.pack.outputs.package-name }}
     steps:
@@ -40,14 +45,14 @@ jobs:
         go-version: 1.16
 
     - name: Build
-      run: go build -ldflags "-s -w" -o almendruco cmd/almendruco/*.go
+      run: bash scripts/build.sh ${BINARY_NAME}
 
     - name: Pack
       id: pack
       run: |
-        PACKAGE_NAME=almendruco-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
-        zip $PACKAGE_NAME almendruco
-        echo "::set-output name=package-name::$PACKAGE_NAME"
+        PACKAGE_NAME=${BINARY_NAME}-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD).zip
+        bash scripts/pack.sh ${BINARY_NAME} ${PACKAGE_NAME}
+        echo "::set-output name=package-name::${PACKAGE_NAME}"
 
     - name: Upload package
       uses: actions/upload-artifact@v2
@@ -62,12 +67,9 @@ jobs:
       - build-and-pack
     permissions:
       id-token: write
+    env:
+      LAMBDA_NAME: almendruco
     steps:
-    - name: Download package
-      uses: actions/download-artifact@v2
-      with:
-        name: package
-
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -75,12 +77,19 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 900
 
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: package
+
     - name: Update lambda (dry-run)
       run: |
-        aws lambda update-function-code \
-          --function-name almendruco \
-          --zip-file fileb://${{ needs.build-and-pack.outputs.package-name }} \
-          --dry-run \
+        bash scripts/update.sh \
+          ${LAMBDA_NAME} \
+          ${{ needs.build-and-pack.outputs.package-name }} \
           >/dev/null
 
   deploy:
@@ -93,12 +102,9 @@ jobs:
       - deploy-dry-run
     permissions:
       id-token: write
+    env:
+      LAMBDA_NAME: almendruco
     steps:
-    - name: Download package
-      uses: actions/download-artifact@v2
-      with:
-        name: package
-
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -106,9 +112,17 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 900
 
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: package
+
     - name: Update lambda
       run: |
-        aws lambda update-function-code \
-          --function-name almendruco \
-          --zip-file fileb://${{ needs.build-and-pack.outputs.package-name }} \
+        bash scripts/update.sh -r \
+          ${LAMBDA_NAME} \
+          ${{ needs.build-and-pack.outputs.package-name }} \
           >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Build artifacts
+almendruco
+almendruco.zip
+
+# Tests output
+.test_coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: lint tidy test check build pack deploy clean
+
+help: ## Show this help
+	@echo "Help"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[36m%-20s\033[93m %s\n", $$1, $$2}'
+
+lint: ## Lint code
+	@bash scripts/lint.sh
+
+tidy: ## Check go.mod file is up to date
+	@bash scripts/tidy.sh
+
+test: ## Run unit tests
+	@bash scripts/test.sh
+
+check: lint tidy test ## Run all checks (lint, tidy, test)
+
+build: ## Compile sources to get a binary
+	@bash scripts/build.sh almendruco
+
+pack: ## Pack a binary built previously so that it can be deployed
+	@bash scripts/pack.sh almendruco almendruco.zip
+
+deploy: ## Deploy code on AWS by updating almendruco function with a previously packaged binary
+	@bash scripts/update.sh -r almendruco almendruco.zip
+
+clean: ## Remove output binary and package
+	rm almendruco almendruco.zip

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Build almendruco binary from sources
+set -eufCo pipefail
+export SHELLOPTS
+
+# Check required commands are in place
+command -v go >/dev/null 2>&1 || { echo "please install go"; exit 1; }
+
+usage() {
+    echo "usage: $(basename $0) <bin_name>" >&2
+}
+
+if [ $# -ne 1 ] ; then
+    echo "[error]: please provide a name for the resulting binary"
+    usage
+    exit 1
+fi
+
+bin_name="${1}"
+
+go build -ldflags "-s -w" -o "${bin_name}" "${PWD}/cmd/almendruco"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Lint code
+set -eufCo pipefail
+export SHELLOPTS
+
+# Check required commands are in place
+command -v golangci-lint >/dev/null 2>&1 || { echo "please install golangci-lint"; exit 1; }
+
+golangci-lint run -E goimports

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Package a binary into file suitable to be deployed
+set -eufCo pipefail
+export SHELLOPTS
+
+usage() {
+    echo "usage: $(basename $0) <bin_name> <package_name>" >&2
+}
+
+if [ $# -ne 2 ] ; then
+    echo "[error]: both a binary name and a package name must be provided"
+    usage
+    exit 1
+fi
+
+bin_name="${1}"
+package_name="${2}"
+
+zip ${package_name} ${bin_name}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Run unit tests and get coverage
+set -eufCo pipefail
+export SHELLOPTS
+
+# Check required commands are in place
+command -v go >/dev/null 2>&1 || { echo "please install go"; exit 1; }
+
+go test -race -coverprofile=.test_coverage.txt ./...
+go tool cover -func=.test_coverage.txt | tail -n1 | awk '{print "Total test coverage: " $3}'

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Check go.mod file is up to date
+
+# Check required commands are in place
+command -v go >/dev/null 2>&1 || { echo "please install go"; exit 1; }
+
+backup_go_mod()
+{
+    mod=$(mktemp)
+    cp go.mod "$mod"
+
+    sum=$(mktemp)
+    cp go.sum "$sum"
+}
+
+restore_go_mod()
+{
+    cp "$mod" go.mod
+    rm "$mod"
+
+    cp "$sum" go.sum
+    rm "$sum"
+}
+
+# Backup actual go.mod and go.sum
+backup_go_mod
+trap restore_go_mod EXIT
+
+go mod tidy
+
+diff "$mod" go.mod || { echo "go.mod file is not up to date"; exit 42; }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Update lambda by uploading a new packaged binary
+# Requires an aws cli credentials profile with enough rights to perform the action
+set -eufCo pipefail
+export SHELLOPTS
+
+# Check required commands are in place
+command -v aws >/dev/null 2>&1 || { echo "please install aws"; exit 1; }
+
+usage() {
+    echo "usage: $(basename $0) [-r] <function_name> <path_to_package>" >&2
+}
+
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "[error]: wrong number of parameters provided"
+    usage
+    exit 1
+fi
+
+for_real=false
+
+while getopts 'r' opt; do
+    case $opt in
+        r) for_real=true ;;
+        *) echo '[error]: command line parsing failed' >&2
+            exit 1
+    esac
+done
+shift "$(( OPTIND - 1 ))"
+
+function_name="${1}"
+path_to_package="${2}"
+
+if [ "$for_real" = true ] ; then
+    aws lambda update-function-code \
+                --function-name "${function_name}" \
+                --zip-file "fileb://${path_to_package}"
+else
+    aws lambda update-function-code \
+                --function-name "${function_name}" \
+                --zip-file "fileb://${path_to_package}" \
+                --dry-run
+fi


### PR DESCRIPTION
Currently, all the actions needed to check code, build, pack and deploy the application are done by issuing bare commands. That works OK in CI, but is not that convenient when working locally from the terminal.

To solve that, a `Makefile` is defined with convenient targets to handle the most common operations for the project. Since it's not great to throw complex commands directly in the `Makefile`, companion scripts are created and invoked instead. By using the scripts in the CI workflow too, we ensure that the same set of actions will be performed no matter where they are invoked. Besides, any change that is required to an operation only needs to be done in the affected script and both CI and local dev environments will get the update.