### PR TITLE
Add support for message attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ almendruco.zip
 
 # Tests output
 .test_coverage.txt
+
+# Local IDE config
+.vscode

--- a/cmd/almendruco/main.go
+++ b/cmd/almendruco/main.go
@@ -17,6 +17,10 @@ import (
 const appName = "almendruco"
 
 func main() {
+	lambda.Start(lambdaHandler())
+}
+
+func lambdaHandler() error {
 	cfg := config{}
 	if err := envconfig.Process(appName, &cfg); err != nil {
 		log.Fatalf("Configuration processing failed: %s", err)
@@ -37,15 +41,13 @@ func main() {
 		log.Fatalf("Error creating notifier: %s", err)
 	}
 
-	lambda.Start(func() error {
-		if err := notifyMessages(r, rc, n); err != nil {
-			return fmt.Errorf("error notifying messages: %s", err)
-		}
-
-		return nil
-	})
+	if err := notifyMessages(r, rc, n); err != nil {
+		return fmt.Errorf("error notifying messages: %s", err)
+	}
 
 	log.Println("Success!")
+
+	return nil
 }
 
 func notifyMessages(r repo.Repo, rc raices.Client, n notifier.Notifier) error {

--- a/internal/raices/client_test.go
+++ b/internal/raices/client_test.go
@@ -23,6 +23,7 @@ func TestFetchMessages(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(loginPath, http.HandlerFunc(happyLoginHandler))
 	mux.Handle(msgPath, http.HandlerFunc(happyMessagesHandler))
+	mux.Handle(attachmentPath, http.HandlerFunc(happyAttachmentHandler))
 
 	svr := httptest.NewServer(mux)
 	defer svr.Close()
@@ -51,8 +52,14 @@ func TestFetchMessages(t *testing.T) {
 		Subject:             "SOME SUBJECT",
 		Body:                "A message with some HTML entities&nbsp; and <div>markup</div>",
 		ContainsAttachments: true,
-		Attachments:         []Attachment{{ID: 123456, FileName: "Some File.ext"}},
-		ReadDate:            time.Date(2021, time.October, 2, 19, 3, 00, 00, cet),
+		Attachments: []Attachment{
+			{
+				ID:       123456,
+				FileName: "Some File.ext",
+				Contents: []byte{1, 2, 3, 4, 5, 6},
+			},
+		},
+		ReadDate: time.Date(2021, time.October, 2, 19, 3, 00, 00, cet),
 	}
 
 	if diff := cmp.Diff(expected, msgs[0]); diff != "" {
@@ -108,6 +115,10 @@ func happyMessagesHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		`
 	fmt.Fprint(w, testResp)
+}
+
+func happyAttachmentHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte{1, 2, 3, 4, 5, 6})
 }
 
 func TestMultiPageMessages(t *testing.T) {
@@ -180,7 +191,7 @@ func multiPageHandler(w http.ResponseWriter, r *http.Request) {
 			Subject:             "SOME SUBJECT",
 			Body:                "A message with some HTML entities&nbsp; and <div>markup</div>",
 			ContainsAttachments: "S",
-			Attachments: []Attachment{
+			Attachments: []rawAttachment{
 				{
 					ID:       123456,
 					FileName: "Some File.ext",

--- a/internal/raices/models.go
+++ b/internal/raices/models.go
@@ -19,14 +19,20 @@ type messagesResponse struct {
 }
 
 type rawMessage struct {
-	ID                  uint64       `json:"X_NOTMENSAL"`
-	SentDate            string       `json:"F_ENVIO"`
-	Sender              string       `json:"REMITIDO"`
-	Subject             string       `json:"T_ASUNTO"`
-	Body                string       `json:"T_MENSAJE"`
-	ContainsAttachments string       `json:"L_ADJUNTO"`
-	Attachments         []Attachment `json:"ADJUNTOS"`
-	ReadDate            string       `json:"F_LECTURA"`
+	ID                  uint64          `json:"X_NOTMENSAL"`
+	SentDate            string          `json:"F_ENVIO"`
+	Sender              string          `json:"REMITIDO"`
+	Subject             string          `json:"T_ASUNTO"`
+	Body                string          `json:"T_MENSAJE"`
+	ContainsAttachments string          `json:"L_ADJUNTO"`
+	Attachments         []rawAttachment `json:"ADJUNTOS"`
+	ReadDate            string          `json:"F_LECTURA"`
+}
+
+type rawAttachment struct {
+	ID       uint64 `json:"X_ADJMENSAL"`
+	FileName string `json:"T_NOMFIC"`
+	Contents []byte
 }
 
 type Message struct {
@@ -41,8 +47,9 @@ type Message struct {
 }
 
 type Attachment struct {
-	ID       uint64 `json:"X_ADJMENSAL"`
-	FileName string `json:"T_NOMFIC"`
+	ID       uint64
+	FileName string
+	Contents []byte
 }
 
 const dateFormat = "02/01/2006 15:04"
@@ -70,6 +77,17 @@ func parseMessage(rm rawMessage) (Message, error) {
 		}
 	}
 
+	attachments := make([]Attachment, len(rm.Attachments))
+	for i, ra := range rm.Attachments {
+		contents := make([]byte, len(ra.Contents))
+		copy(contents, ra.Contents)
+		attachments[i] = Attachment{
+			ID:       ra.ID,
+			FileName: ra.FileName,
+			Contents: contents,
+		}
+	}
+
 	return Message{
 		ID:                  rm.ID,
 		SentDate:            sentDate,
@@ -77,7 +95,7 @@ func parseMessage(rm rawMessage) (Message, error) {
 		Subject:             rm.Subject,
 		Body:                rm.Body,
 		ContainsAttachments: rm.ContainsAttachments == "S",
-		Attachments:         rm.Attachments,
+		Attachments:         attachments,
 		ReadDate:            readDate,
 	}, nil
 }


### PR DESCRIPTION
Raíces supports documents and pictures to be attached to messages. Until now, `almendruco` was getting and displaying attachment details on every message. However, the attachments themselves were not downloaded, requiring the user to log into Raíces to fetch the attached documents.

With these changes, binary contents of attachments are downloaded for messages that hasn't been notified yet. Then, they are notified just after the message is sent.

### Implementation considerations

- No checks are imposed on attachment size. While we should play it safe here, I'm relying on the limitations of Raíces itself.

- For now, all attachments are sent using Telegram's API `sendDocument`, no matter what type (picture, document, etc.) they are. There are more specific methods in Telegram's API that could be used doing a basic detection of the attachment contents (using the `Content-Type` header received when downloading them from the server or the file name extension). This is something I'll do in the future if/when I have more details about how the current implementation behaves with different attachment types.