### PR TITLE
Lambda handler improvements

### DIFF
--- a/cmd/almendruco/main.go
+++ b/cmd/almendruco/main.go
@@ -23,26 +23,26 @@ func main() {
 func lambdaHandler() error {
 	cfg := config{}
 	if err := envconfig.Process(appName, &cfg); err != nil {
-		log.Fatalf("Configuration processing failed: %s", err)
+		return fmt.Errorf("configuration processing failed: %w", err)
 	}
 
 	r, err := dynamodbrepo.NewRepo()
 	if err != nil {
-		log.Fatalf("Unable to initialize repository: %s", err)
+		return fmt.Errorf("unable to initialize repository: %w", err)
 	}
 
 	rc, err := raices.NewClient(cfg.Raices.BaseURL)
 	if err != nil {
-		log.Fatalf("Error creating Raíces client: %s", err)
+		return fmt.Errorf("error creating Raíces client: %w", err)
 	}
 
 	n, err := notifier.NewTelegramNotifier(cfg.Telegram.BaseURL, cfg.Telegram.BotToken)
 	if err != nil {
-		log.Fatalf("Error creating notifier: %s", err)
+		return fmt.Errorf("error creating notifier: %w", err)
 	}
 
 	if err := notifyMessages(r, rc, n); err != nil {
-		return fmt.Errorf("error notifying messages: %s", err)
+		return fmt.Errorf("error notifying messages: %w", err)
 	}
 
 	log.Println("Success!")

--- a/cmd/almendruco/main.go
+++ b/cmd/almendruco/main.go
@@ -17,7 +17,7 @@ import (
 const appName = "almendruco"
 
 func main() {
-	lambda.Start(lambdaHandler())
+	lambda.Start(lambdaHandler)
 }
 
 func lambdaHandler() error {


### PR DESCRIPTION
This PR implements improvements to the main lambda handler:
- Fixes the lambda executor always reporting `nil handler` error. `lambda.Start` expects a handler function, but the handler was being executed and the result was being passed to `lambda.Start` instead of the function itself.
- Improves error handling. Errors were being logged but not returned.